### PR TITLE
Fixed: module install fails if lock file generated on Windows 10/Serv…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ## Fixed
 
 * Fixed: `prism install` always installs modules, even if they are already installed.
+* Fixed: module install fails if lock file generated on Windows 10/Server 2016 or later and install is on Windows
+  8.1/Server 2012 R2 and vice-versa. (PSGallery repository's URL ends with a forward slash on
+  Windows 8.1/Server 2012 R2, but ends with no forward slash on later operating systems.)
 
 
 # 0.3.0

--- a/Tests/install.Tests.ps1
+++ b/Tests/install.Tests.ps1
@@ -298,4 +298,57 @@ Describe 'prism install' {
         WhenInstalling
         Assert-MockCalled -CommandName 'Save-Module' -ModuleName 'Prism' -Times 0 -Exactly
     }
+
+    It 'should handle missing forward slash on PSGallery location on older platforms' {
+        GivenPrismFile @'
+        {
+            "PSModules": [
+                {
+                    "Name": "NoOp",
+                    "Version": "1.*"
+                }
+            ]
+        }
+'@
+        GivenLockFile @'
+{
+    "PSModules":  [
+        {
+            "name":  "NoOp",
+            "version":  "1.0.0",
+            "repositorySourceLocation":  "https://www.powershellgallery.com/api/v2"
+        }
+    ]
+}
+'@
+        WhenInstalling
+        ThenInstalled @{ 'NoOp' = '1.0.0' }
+    }
+
+
+    It 'should handle extra forward slash on PSGallery location' {
+        GivenPrismFile @'
+        {
+            "PSModules": [
+                {
+                    "Name": "NoOp",
+                    "Version": "1.*"
+                }
+            ]
+        }
+'@
+        GivenLockFile @'
+{
+    "PSModules":  [
+        {
+            "name":  "NoOp",
+            "version":  "1.0.0",
+            "repositorySourceLocation":  "https://www.powershellgallery.com/api/v2/"
+        }
+    ]
+}
+'@
+        WhenInstalling
+        ThenInstalled @{ 'NoOp' = '1.0.0' }
+    }
 }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,6 +59,8 @@ for:
       }
       finally
       {
+          Get-Module | Format-Table -Auto | Out-String
+          Get-Module 'PackageManagement', 'PowerShellGet' -ListAvailable | Format-Table -Auto | Out-String
           $Global:Error | Format-List * -Force
       }
 
@@ -75,5 +77,7 @@ for:
       }
       finally
       {
+          Get-Module | Format-Table -Auto | Out-String
+          Get-Module 'PackageManagement', 'PowerShellGet' -ListAvailable | Format-Table -Auto | Out-String
           $Global:Error | Format-List * -Force
       }


### PR DESCRIPTION
…er 2016 or later and install is on Windows 8.1/Server 2012 R2 and vice-versa.

Also, PackageManagement 1.4.8 is out, but causes problems in our environments, so I have to uninstall it.