### PR TITLE
0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 0.5.0
+
+## Changed
+
+* Prism supports PackageManagement versions 1.3.2 through 1.4.7.
+* Prism supports PowerShellGet versions 2.0.0 through 2.2.5.
+
+## Fixed
+
+* Fixed: Prism commands fail if PowerShellGet and PackageManagement modules aren't already imported before being run.
+
+
 # 0.4.0
 
 ## Added

--- a/Prism/Functions/Invoke-Prism.ps1
+++ b/Prism/Functions/Invoke-Prism.ps1
@@ -53,8 +53,18 @@ function Invoke-Prism
 
         Write-Debug 'AVAILABLE MODULES'
         Get-Module -ListAvailable | Format-Table -AutoSize | Out-String | Write-Debug
-        Import-Module -Name 'PackageManagement' @pkgMgmtPrefs -ErrorAction Stop
-        Import-Module -Name 'PowerShellGet' @pkgMgmtPrefs -ErrorAction Stop
+        Import-Module -Name 'PackageManagement' `
+                      -MinimumVersion '1.3.2' `
+                      -MaximumVersion '1.4.7' `
+                      -Global `
+                      -ErrorAction Stop `
+                      @pkgMgmtPrefs
+        Import-Module -Name 'PowerShellGet' `
+                      -MinimumVersion '2.0.0' `
+                      -MaximumVersion '2.2.5' `
+                      -Global `
+                      -ErrorAction Stop `
+                      @pkgMgmtPrefs
         Write-Debug 'IMPORTED MODULES'
         Get-Module | Format-Table -AutoSize | Out-String | Write-Debug
 

--- a/Prism/Prism.psd1
+++ b/Prism/Prism.psd1
@@ -18,7 +18,7 @@
     RootModule = 'Prism.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.4.0'
+    ModuleVersion = '0.5.0'
 
     # ID used to uniquely identify this module
     GUID = '5b244346-40c9-4a50-a098-8758c19f7f25'

--- a/Tests/Invoke-Prism.Tests.ps1
+++ b/Tests/Invoke-Prism.Tests.ps1
@@ -41,6 +41,19 @@ BeforeAll {
         ThenWroteError -ThatMatches $WithErrorMatching
     }
 
+    function ThenPackageManagementModulesImported
+    {
+        Get-Module -Name 'PackageManagement' |
+            Where-Object 'Version' -ge ([Version]'1.3.2') |
+            Where-Object 'Version' -le ([Version]'1.4.7') |
+            Should -Not -BeNullOrEmpty -Because 'should import PackageManagement 1.3.2 - 1.4.7'
+
+        Get-Module -Name 'PowerShellGet' |
+            Where-Object 'Version' -ge ([Version]'2.0.0') |
+            Where-Object 'Version' -le ([Version]'2.2.5') |
+            Should -Not -BeNullOrEmpty -Because 'should import PowerShellGet 2.0.0 - 2.2.5'
+    }
+
     function ThenRanCommand
     {
         [CmdletBinding()]
@@ -190,6 +203,7 @@ Describe 'Invoke-Prism' {
         New-Item -Path $script:testRoot -ItemType 'Directory'
         Push-Location $script:testRoot
         $Global:Error.Clear()
+        Remove-Module -Name 'PowerShellGet', 'PackageManagement' -Force -ErrorAction Ignore
     }
 
     AfterEach {
@@ -208,6 +222,7 @@ Describe 'Invoke-Prism' {
             GivenPrismFile 'dir1\prism.json'
             WhenInvokingCommand $command
             ThenRanCommand $command -Passing @{ 'Path' = 'prism.json'; 'LockPath' = 'prism.lock.json' }
+            ThenPackageManagementModulesImported
         }
 
         It 'should pass all configuration files' {
@@ -223,6 +238,7 @@ Describe 'Invoke-Prism' {
                 @{ Path = 'dir1\dir2\prism.json' ; LockPath = 'dir1\dir2\prism.lock.json' },
                 @{ Path = 'dir3\dir4\prism.json' ; LockPath = 'dir3\dir4\prism.lock.json' }
             )
+            ThenPackageManagementModulesImported
         }
     }
 


### PR DESCRIPTION
Fixed: Prism fails if PowerShellGet and PackageManagement aren't already imported globally. Lowered minimum allowed versions of PackageManagement (1.3.2) and PowerShellGet (2.0.0).