### PR TITLE
 PowerShell has a scope stack limit not a nested directory limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@
 
 # Prism Changelog
 
+## 0.9.0
+
+Turns out, the 10 directory nesting limit for nested modules is a scope stack limit, not a directory limit. This version
+of Prism now installs nested modules into a "Modules" directory instead of directly in the module directory. You can
+preserve the old behavior and install modules directly in the module directory by setting the "PSModulesDirectoryName"
+configuration property in the prism.json file to `.`.
+
 ## 0.8.1
+
+> Released 19 Nov 2024
 
 Fixed: Prism fails to install new versions of nested modules if old versions are installed.
 

--- a/Prism/Functions/Install-PrivateModule.ps1
+++ b/Prism/Functions/Install-PrivateModule.ps1
@@ -48,14 +48,6 @@ function Install-PrivateModule
 
         $installedModules =
             & {
-                if ($Configuration.Nested)
-                {
-                    Get-ChildItem -Path $Configuration.InstallDirectoryPath -Recurse | Out-String | Write-Debug
-                    Get-ChildItem -Path (Join-Path -Path $Configuration.InstallDirectoryPath -ChildPath '*\*.psd1') |
-                        ForEach-Object { Get-Module -Name $_.FullName -ListAvailable -ErrorAction Ignore }
-                }
-                else
-                {
                     $origPSModulePath = $env:PSModulePath
                     $env:PSModulePath = $Configuration.InstallDirectoryPath
                     try
@@ -67,7 +59,6 @@ function Install-PrivateModule
                     {
                         $env:PSModulePath = $origPSModulePath
                     }
-                }
             } |
             Add-Member -Name 'SemVer' -MemberType ScriptProperty -PassThru -Value {
                 $prerelease = $this.PrivateData['PSData']['PreRelease']
@@ -146,9 +137,8 @@ function Install-PrivateModule
                         -Repository $repoName `
                         @pkgMgmtPrefs
 
-            # PowerShell has a 10 directory limit for nested modules, so reduce the number of nested directories
-            # when installing a nested module by installing directly in the module root directory and moving
-            # everything out of the version module directory.
+            # Windows has a 260 character limit for path length. Reduce paths by removing extraneous version
+            # directories.
             if ($nestedSingleVersion)
             {
                 $modulePath = Join-Path -Path $installDirPath -ChildPath $module.name

--- a/Prism/Prism.psd1
+++ b/Prism/Prism.psd1
@@ -18,7 +18,7 @@
     RootModule = 'Prism.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.8.1'
+    ModuleVersion = '0.9.0'
 
     # ID used to uniquely identify this module
     GUID = '5b244346-40c9-4a50-a098-8758c19f7f25'

--- a/README.md
+++ b/README.md
@@ -108,17 +108,21 @@ a `prism.lock.json` file, with the specific versions of each module to install. 
 install` will only install the module versions listed in the lock file. To update the versions in the lock file to
 newer versions or to reflect changes made to the `prism.json` file, run `prism update`.
 
-### Output Directory
+### Where Prism Installs/Saves Modules
 
-Modules will always be saved in the same directory as the "prism.json" file, in a directory named "PSModules". You can
-customize this directory name with the `PSModulesDirectoryName` option in your `prism.json` file:
+Modules will always be saved in the same directory as the "prism.json" file, in a directory named "PSModules". If
+installing nested modules for a module (i.e. the install directory contains a .psd1 or .psm1 file), modules are saved to
+a "Modules" directory. You can customize this directory name with the `PSModulesDirectoryName` option in your
+`prism.json` file:
 
 ```json
 {
     "PSModules": [],
-    "PSModulesDirectoryName": "Modules"
+    "PSModulesDirectoryName": "SomeOtherDirName"
 }
 ```
+
+To install modules in the same directory as the "prism.json" file, use `.` as the "PSModulesDirectoryName" value.
 
 To put the PSModules directory in a *different* directory, put a "prism.json" file in that directory. Use the "prism"
 command's `-Recurse` switch to run prism against every prism.json file under the current directory.
@@ -139,16 +143,7 @@ Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath 'PSModules\Whiskey
 Import-Module -Name (Join-Path -Path $PSScriptRoot -ChildPath '..\PSModules\Whiskey' -Resolve)
 ```
 
-## Using Nested Modules in a Module
-
-### Installing
-
-PowerShell has a 10 directory nested limit for nested modules. When using nested modules in a module, in order to avoid
-errors about too much nesting, Prism will install the modules directly into your module directory and will also *not*
-install modules into a version-specific directory. Prism automatically detects when installing into a module directory
-by looking for a .psd1 or .psm1 file in the same directory as the prism.json file.
-
-### Importing
+### Importing Nested Modules
 
 To import and use a private, nested module installed by Prism, use `Import-Module` and pass the path to the module
 instead of a module name. Use `Join-Path` and join the path to your module's directory with the relative path to the
@@ -168,14 +163,14 @@ Import-Module -Name (Join-Path -Path $script:moduleDirPath -ChildPath 'Whiskey' 
 ***DO*** always use the `Import-Module` cmdlet's `Alias`, `Cmdlet`, and `Function` parameters to explicitly list what
 commands your script is importing and using. It makes upgrading easier when you know what commands you're using.
 
-***DO NOT*** depend on PowerShell's automatic module loading. That functionality won't see the private modules in
-"PSModules".
+***DO NOT*** depend on PowerShell's automatic module loading. That functionality won't see the private modules Prism
+installs.
 
 #### When Writing Modules
 
 ***DO*** ship your module's dependencies as nested modules. Use Prism to manage these as it structures dependencies to
-avoid deep nesting errors. Import dependencies from that private location. A module can have its own version of a module
-loaded privately.
+avoid long directory paths. Import dependencies from that private location. A module can have its own version of a
+module loaded privately.
 
 ***DO NOT*** use the `NestedModules` module manifest property. Use an explicit `Import-Module` in your root module to
 import dependencies saved inside your module.


### PR DESCRIPTION
The nesting limit is actually a scope stack limit, not a file system limit so put nested modules back into a directory, with the ability to install directly in the module directory.