### PR TITLE
Fixed: Prism can leave private modules in an unusable state when it installs modules in a directory being watched or scanned by other processes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,20 @@
 
 # Prism Changelog
 
+## 0.11.2
+
+Fixed: `prism install` can leave private module directories in an unusable state when it installs modules into a
+directory being watched or scanned by other processes.
+
 ## 0.11.1
+
+> Released 14 Jan 2025
 
 Fixed: `prism install` fails to install modules that use a NuGet 4-segment version number (e.g. 2.5.0.214).
 
 ## 0.11.0
+
+> Released 19 Dec 2024
 
 ### Added
 

--- a/Prism/Functions/Install-PrivateModule.ps1
+++ b/Prism/Functions/Install-PrivateModule.ps1
@@ -148,8 +148,8 @@ function Install-PrivateModule
                     $versionDirName = $Matches[1]
                 }
                 $moduleVersionPath = Join-Path -Path $modulePath -ChildPath $versionDirName
-                Get-ChildItem -Path $moduleVersionPath -Force | Move-Item -Destination $modulePath
-                Get-Item -Path $moduleVersionPath | Remove-Item
+                Get-ChildItem -Path $moduleVersionPath -Force | Copy-Item -Destination $modulePath -Recurse
+                Get-Item -Path $moduleVersionPath | Remove-Item -Force -Recurse
             }
 
             $modulePath = Join-Path -Path $installDirPath -ChildPath $module.name | Resolve-Path -Relative

--- a/Prism/Prism.psd1
+++ b/Prism/Prism.psd1
@@ -18,7 +18,7 @@
     RootModule = 'Prism.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.11.1'
+    ModuleVersion = '0.11.2'
 
     # ID used to uniquely identify this module
     GUID = '5b244346-40c9-4a50-a098-8758c19f7f25'


### PR DESCRIPTION
…